### PR TITLE
removed unnecessary express and wrong mongoose info

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/anishkny/node-express-realworld-example-app.svg?branch=master)](https://travis-ci.org/anishkny/node-express-realworld-example-app)
 
-> ### NestJS (Express + Mongoose) codebase containing real world examples (CRUD, auth, advanced patterns, etc) that adheres to the [RealWorld](https://github.com/gothinkster/realworld-example-apps) API spec.
+> ### NestJS codebase containing real world examples (CRUD, auth, advanced patterns, etc) that adheres to the [RealWorld](https://github.com/gothinkster/realworld-example-apps) API spec.
 
 
 ----------


### PR DESCRIPTION
Title.

Don't see why appoint the default platform used by NestJS, it may be misleading for newbies and Mongoose is not being used, since Database section already contains info about DB and ORM it seems duplication of information (I guess the point proves itself with mongoose citation).