### PR TITLE
fix: can not get user id by @User('id')

### DIFF
--- a/src/user/auth.middleware.ts
+++ b/src/user/auth.middleware.ts
@@ -20,8 +20,9 @@ export class AuthMiddleware implements NestMiddleware {
       if (!user) {
         throw new HttpException('User not found.', HttpStatus.UNAUTHORIZED);
       }
-
+      
       req.user = user.user;
+      req.user.id = decoded.id;
       next();
 
     } else {


### PR DESCRIPTION
req.user added in auth.middleware has no id property, which makes it impossible to get a user id with @user ('id'), for example, when updating a user.