### PR TITLE
fix: creation of a new article deletes the author ids of the previous articles

### DIFF
--- a/src/article/article.service.ts
+++ b/src/article/article.service.ts
@@ -173,7 +173,7 @@ export class ArticleService {
 
     const newArticle = await this.articleRepository.save(article);
 
-    const author = await this.userRepository.findOne({ where: { id: userId } });
+    const author = await this.userRepository.findOne({ where: { id: userId }, relations: ["articles"] });
 
     if (Array.isArray(author.articles)) {
       author.articles.push(article);

--- a/src/user/auth.middleware.ts
+++ b/src/user/auth.middleware.ts
@@ -8,7 +8,7 @@ import { UserService } from './user.service';
 
 @Injectable()
 export class AuthMiddleware implements NestMiddleware {
-  constructor(private readonly userService: UserService) {}
+  constructor(private readonly userService: UserService) { }
 
   async use(req: Request, res: Response, next: NextFunction) {
     const authHeaders = req.headers.authorization;
@@ -22,6 +22,7 @@ export class AuthMiddleware implements NestMiddleware {
       }
 
       req.user = user.user;
+      req.user.id = decoded.id;
       next();
 
     } else {


### PR DESCRIPTION
As @Linjovi has shown, it is necessary for auth.middleware.ts to know the user id (fixes `TypeError: Cannot read property 'articles' of undefined` in `article.service.ts` line 178). 
Furthermore, when creating a new article via post request, the author id for all previous articles is set to NULL, because `const author = await this.userRepository.findOne({ where: { id: userId } });` returns an user object, which has no property articles. Therefore `if (Array.isArray(author.articles))` is always false and only for the newest article the author id is set.

